### PR TITLE
docs: add MIT license badge to README (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AI Architect Portfolio — RTP Project (Ray Tong)
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 A high-end, professional showcase for an **AI Architect** specializing in agentic systems, advanced RAG architectures, and production-grade LLM workflows. This project serves as a technical portfolio to demonstrate expertise in building scalable, modern AI solutions.
 
 ## 🎯 Overview


### PR DESCRIPTION
Added a prominent MIT license badge at the top of README.md to clearly indicate the project's license type.

This makes the license information more visible to visitors and follows common best practices for open-source projects on GitHub.