### PR TITLE
Fix: Update blog theme for RAG vs Long Context page

### DIFF
--- a/src/app/blog/BlogPostLayout.tsx
+++ b/src/app/blog/BlogPostLayout.tsx
@@ -12,14 +12,14 @@ interface BlogPostProps {
 
 export function BlogPostLayout({ title, date, readTime, category, content, tags }: BlogPostProps) {
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100 font-sans">
-      <nav className="fixed top-0 w-full z-50 border-b border-slate-800/50 bg-slate-950/80 backdrop-blur-md">
+    <div className="min-h-screen bg-[#0a0a0a] text-[#00ff41] font-mono">
+      <nav className="fixed top-0 w-full z-50 border-b border-[#003b00] bg-[#050505]/90 backdrop-blur-md">
         <div className="max-w-4xl mx-auto px-6 h-16 flex items-center justify-between">
-          <Link href="/#insights" className="flex items-center gap-2 text-sm text-slate-400 hover:text-indigo-400 transition-colors">
-            <ArrowLeft size={16} /> Back to Insights
+          <Link href="/#insights" className="flex items-center gap-2 text-sm text-[#00ff41]/70 hover:text-[#00ff41] transition-colors">
+            <ArrowLeft size={16} /> BACK_TO_INSIGHTS
           </Link>
-          <span className="font-bold text-lg tracking-tight hidden sm:inline-block">
-            RAY TONG <span className="text-indigo-400">/ BLOG</span>
+          <span className="font-bold text-lg tracking-tight hidden sm:inline-block neon-glow">
+            RAY TONG <span className="text-[#00ff41]">/ BLOG</span>
           </span>
         </div>
       </nav>
@@ -27,13 +27,13 @@ export function BlogPostLayout({ title, date, readTime, category, content, tags 
       <main className="pt-32 pb-24 px-6">
         <article className="max-w-3xl mx-auto">
           <header className="mb-12">
-            <div className="flex items-center gap-4 text-sm text-indigo-400 mb-4 font-medium uppercase tracking-wider">
+            <div className="flex items-center gap-4 text-sm text-[#00ff41] mb-4 font-bold uppercase tracking-widest">
               <span>{category}</span>
             </div>
-            <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-8 leading-tight">
+            <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-8 leading-tight neon-glow text-white">
               {title}
             </h1>
-            <div className="flex flex-wrap items-center gap-6 text-slate-400 text-sm border-y border-slate-800/50 py-4">
+            <div className="flex flex-wrap items-center gap-6 text-[#00ff41]/60 text-sm border-y border-[#003b00] py-4">
               <div className="flex items-center gap-2">
                 <Calendar size={16} /> {date}
               </div>
@@ -46,34 +46,34 @@ export function BlogPostLayout({ title, date, readTime, category, content, tags 
             </div>
           </header>
 
-          <div className="prose prose-invert prose-indigo max-w-none 
-            prose-headings:font-bold prose-headings:tracking-tight
-            prose-p:text-slate-300 prose-p:leading-relaxed prose-p:mb-6
-            prose-strong:text-white prose-code:text-indigo-300
-            prose-blockquote:border-l-indigo-500 prose-blockquote:bg-indigo-500/5 prose-blockquote:py-1 prose-blockquote:px-6 prose-blockquote:rounded-r-lg
+          <div className="prose prose-invert prose-emerald max-w-none 
+            prose-headings:font-bold prose-headings:tracking-tight prose-headings:text-white
+            prose-p:text-[#00ff41]/80 prose-p:leading-relaxed prose-p:mb-6
+            prose-strong:text-white prose-code:text-[#00ff41]
+            prose-blockquote:border-l-[#00ff41] prose-blockquote:bg-[#00ff41]/5 prose-blockquote:py-1 prose-blockquote:px-6 prose-blockquote:rounded-r-lg prose-blockquote:text-[#00ff41]
           ">
             {content}
           </div>
 
-          <footer className="mt-16 pt-8 border-t border-slate-800/50">
+          <footer className="mt-16 pt-8 border-t border-[#003b00]">
             <div className="flex flex-wrap justify-between items-center gap-6">
               <div className="flex gap-4">
-                <button className="flex items-center gap-2 px-4 py-2 bg-slate-900 border border-slate-800 rounded-lg hover:border-indigo-500/50 transition-all text-sm">
-                  <Share2 size={16} /> Share
+                <button className="flex items-center gap-2 px-4 py-2 bg-[#050505] border border-[#003b00] rounded hover:border-[#00ff41] transition-all text-sm">
+                  <Share2 size={16} /> SHARE
                 </button>
-                <button className="flex items-center gap-2 px-4 py-2 bg-slate-900 border border-slate-800 rounded-lg hover:border-indigo-500/50 transition-all text-sm">
-                  <MessageSquare size={16} /> Discuss
+                <button className="flex items-center gap-2 px-4 py-2 bg-[#050505] border border-[#003b00] rounded hover:border-[#00ff41] transition-all text-sm">
+                  <MessageSquare size={16} /> DISCUSS
                 </button>
               </div>
-              <Link href="/#insights" className="text-indigo-400 hover:text-indigo-300 font-medium flex items-center gap-2 transition-colors">
-                Read more insights <ArrowLeft size={16} className="rotate-180" />
+              <Link href="/#insights" className="text-[#00ff41] hover:text-white font-bold flex items-center gap-2 transition-colors">
+                READ_MORE <ArrowLeft size={16} className="rotate-180" />
               </Link>
             </div>
           </footer>
         </article>
       </main>
 
-      <footer className="py-12 px-6 text-center text-sm text-slate-500 border-t border-slate-900 bg-slate-900/20">
+      <footer className="py-12 px-6 text-center text-sm text-[#00ff41]/30 border-t border-[#003b00] bg-[#050505]">
         <p className="mb-4">Architecting the future of agentic systems.</p>
         &copy; {new Date().getFullYear()} Ray Tong.
       </footer>

--- a/src/app/blog/rag-vs-long-context/page.tsx
+++ b/src/app/blog/rag-vs-long-context/page.tsx
@@ -10,7 +10,7 @@ export default function Post() {
       tags={["RAG", "LLMs", "Optimization", "Architecture"]}
       content={
         <>
-          <p className="text-xl text-indigo-200/90 leading-relaxed italic mb-8 border-l-4 border-indigo-500 pl-6 py-2 bg-indigo-500/5">
+          <p className="text-xl text-[#00ff41]/90 leading-relaxed italic mb-8 border-l-4 border-[#00ff41] pl-6 py-2 bg-[#00ff41]/5">
             As model context windows expand to millions of tokens, a common question arises: Is Retrieval-Augmented Generation (RAG) obsolete?
           </p>
 
@@ -18,7 +18,7 @@ export default function Post() {
           <p>
             With the advent of models like Gemini 1.5 Pro and GPT-4o supporting massive context windows, it is tempting to simply &quot;stuff&quot; all documentation and data into the prompt. However, from an architectural standpoint, this approach often introduces significant challenges:
           </p>
-          <ul className="list-disc pl-6 mb-8 space-y-4 text-slate-300">
+          <ul className="list-disc pl-6 mb-8 space-y-4 text-[#00ff41]/70">
             <li><strong>Latency:</strong> Processing millions of tokens is computationally expensive and slow.</li>
             <li><strong>Cost:</strong> Token usage scales linearly (or worse) with context size, leading to unsustainable operational costs.</li>
             <li><strong>Recall (Lost in the Middle):</strong> Models still struggle with &quot;needle-in-a-haystack&quot; accuracy when the context is overly cluttered with irrelevant information.</li>
@@ -29,7 +29,7 @@ export default function Post() {
             An elite AI architecture does not choose between RAG and Long Context; it integrates both. RAG serves as the <strong>efficient filter</strong>, narrowing down terabytes of data to the most relevant megabytes. Long context then provides the <strong>reasoning canvas</strong> for the model to synthesize those findings with high precision.
           </p>
           
-          <blockquote className="my-10 border-l-4 border-indigo-500 bg-indigo-500/5 px-8 py-6 rounded-r-xl italic text-lg text-slate-200">
+          <blockquote className="my-10 border-l-4 border-[#00ff41] bg-[#00ff41]/5 px-8 py-6 rounded-r-xl italic text-lg text-[#00ff41]/90">
             &quot;RAG is about efficiency and scale; Long Context is about depth and reasoning. The magic happens when they overlap.&quot;
           </blockquote>
 
@@ -37,7 +37,7 @@ export default function Post() {
           <p>
             For production-grade systems, architects should focus on:
           </p>
-          <ol className="list-decimal pl-6 mb-8 space-y-4 text-slate-300">
+          <ol className="list-decimal pl-6 mb-8 space-y-4 text-[#00ff41]/70">
             <li><strong>Semantic Compression:</strong> Using smaller, specialized models to summarize retrieved context before passing it to the reasoning LLM.</li>
             <li><strong>Multi-stage Retrieval:</strong> Combining BM25, vector search, and cross-encoder reranking to ensure only the highest quality context is used.</li>
             <li><strong>Dynamic Context Management:</strong> Automatically adjusting the context size based on the complexity of the query and the required accuracy.</li>


### PR DESCRIPTION
Addresses issue #38: Fix the old color theme on the RAG vs Long Context blog page by updating the layout and page components to use the new matrix green theme variables.